### PR TITLE
fix: fully qualify shadowed Metadata and TransactionType references in WebhookPayload

### DIFF
--- a/dodo-payments-kotlin-core/src/main/kotlin/com/dodopayments/api/models/webhookevents/WebhookPayload.kt
+++ b/dodo-payments-kotlin-core/src/main/kotlin/com/dodopayments/api/models/webhookevents/WebhookPayload.kt
@@ -658,7 +658,7 @@ private constructor(
             private val customer: JsonField<CustomerLimitedDetails>,
             private val digitalProductsDelivered: JsonField<Boolean>,
             private val disputes: JsonField<List<Dispute>>,
-            private val metadata: JsonField<Payment.Metadata>,
+            private val metadata: JsonField<com.dodopayments.api.models.payments.Payment.Metadata>,
             private val paymentId: JsonField<String>,
             private val refunds: JsonField<List<RefundListItem>>,
             private val settlementAmount: JsonField<Int>,
@@ -718,7 +718,7 @@ private constructor(
                 disputes: JsonField<List<Dispute>> = JsonMissing.of(),
                 @JsonProperty("metadata")
                 @ExcludeMissing
-                metadata: JsonField<Payment.Metadata> = JsonMissing.of(),
+                metadata: JsonField<com.dodopayments.api.models.payments.Payment.Metadata> = JsonMissing.of(),
                 @JsonProperty("payment_id")
                 @ExcludeMissing
                 paymentId: JsonField<String> = JsonMissing.of(),
@@ -962,7 +962,7 @@ private constructor(
              *   is unexpectedly missing or null (e.g. if the server responded with an unexpected
              *   value).
              */
-            fun metadata(): Payment.Metadata = metadata.getRequired("metadata")
+            fun metadata(): com.dodopayments.api.models.payments.Payment.Metadata = metadata.getRequired("metadata")
 
             /**
              * Unique identifier for the payment
@@ -1287,7 +1287,7 @@ private constructor(
              */
             @JsonProperty("metadata")
             @ExcludeMissing
-            fun _metadata(): JsonField<Payment.Metadata> = metadata
+            fun _metadata(): JsonField<com.dodopayments.api.models.payments.Payment.Metadata> = metadata
 
             /**
              * Returns the raw JSON value of [paymentId].
@@ -1610,7 +1610,7 @@ private constructor(
                 private var customer: JsonField<CustomerLimitedDetails>? = null
                 private var digitalProductsDelivered: JsonField<Boolean>? = null
                 private var disputes: JsonField<MutableList<Dispute>>? = null
-                private var metadata: JsonField<Payment.Metadata>? = null
+                private var metadata: JsonField<com.dodopayments.api.models.payments.Payment.Metadata>? = null
                 private var paymentId: JsonField<String>? = null
                 private var refunds: JsonField<MutableList<RefundListItem>>? = null
                 private var settlementAmount: JsonField<Int>? = null
@@ -1803,16 +1803,16 @@ private constructor(
                 }
 
                 /** Additional custom data associated with the payment */
-                fun metadata(metadata: Payment.Metadata) = metadata(JsonField.of(metadata))
+                fun metadata(metadata: com.dodopayments.api.models.payments.Payment.Metadata) = metadata(JsonField.of(metadata))
 
                 /**
                  * Sets [Builder.metadata] to an arbitrary JSON value.
                  *
-                 * You should usually call [Builder.metadata] with a well-typed [Payment.Metadata]
+                 * You should usually call [Builder.metadata] with a well-typed [com.dodopayments.api.models.payments.Payment.Metadata]
                  * value instead. This method is primarily for setting the field to an undocumented
                  * or not yet supported value.
                  */
-                fun metadata(metadata: JsonField<Payment.Metadata>) = apply {
+                fun metadata(metadata: JsonField<com.dodopayments.api.models.payments.Payment.Metadata>) = apply {
                     this.metadata = metadata
                 }
 
@@ -2708,7 +2708,7 @@ private constructor(
             private val creditEntitlementCart: JsonField<List<CreditEntitlementCartResponse>>,
             private val currency: JsonField<Currency>,
             private val customer: JsonField<CustomerLimitedDetails>,
-            private val metadata: JsonField<Subscription.Metadata>,
+            private val metadata: JsonField<com.dodopayments.api.models.subscriptions.Subscription.Metadata>,
             private val meterCreditEntitlementCart:
                 JsonField<List<MeterCreditEntitlementCartResponse>>,
             private val meters: JsonField<List<MeterCartResponseItem>>,
@@ -2763,7 +2763,7 @@ private constructor(
                 customer: JsonField<CustomerLimitedDetails> = JsonMissing.of(),
                 @JsonProperty("metadata")
                 @ExcludeMissing
-                metadata: JsonField<Subscription.Metadata> = JsonMissing.of(),
+                metadata: JsonField<com.dodopayments.api.models.subscriptions.Subscription.Metadata> = JsonMissing.of(),
                 @JsonProperty("meter_credit_entitlement_cart")
                 @ExcludeMissing
                 meterCreditEntitlementCart: JsonField<List<MeterCreditEntitlementCartResponse>> =
@@ -2978,7 +2978,7 @@ private constructor(
              *   is unexpectedly missing or null (e.g. if the server responded with an unexpected
              *   value).
              */
-            fun metadata(): Subscription.Metadata = metadata.getRequired("metadata")
+            fun metadata(): com.dodopayments.api.models.subscriptions.Subscription.Metadata = metadata.getRequired("metadata")
 
             /**
              * Meter credit entitlement cart settings for this subscription
@@ -3274,7 +3274,7 @@ private constructor(
              */
             @JsonProperty("metadata")
             @ExcludeMissing
-            fun _metadata(): JsonField<Subscription.Metadata> = metadata
+            fun _metadata(): JsonField<com.dodopayments.api.models.subscriptions.Subscription.Metadata> = metadata
 
             /**
              * Returns the raw JSON value of [meterCreditEntitlementCart].
@@ -3571,7 +3571,7 @@ private constructor(
                     null
                 private var currency: JsonField<Currency>? = null
                 private var customer: JsonField<CustomerLimitedDetails>? = null
-                private var metadata: JsonField<Subscription.Metadata>? = null
+                private var metadata: JsonField<com.dodopayments.api.models.subscriptions.Subscription.Metadata>? = null
                 private var meterCreditEntitlementCart:
                     JsonField<MutableList<MeterCreditEntitlementCartResponse>>? =
                     null
@@ -3765,16 +3765,16 @@ private constructor(
                 }
 
                 /** Additional custom data associated with the subscription */
-                fun metadata(metadata: Subscription.Metadata) = metadata(JsonField.of(metadata))
+                fun metadata(metadata: com.dodopayments.api.models.subscriptions.Subscription.Metadata) = metadata(JsonField.of(metadata))
 
                 /**
                  * Sets [Builder.metadata] to an arbitrary JSON value.
                  *
                  * You should usually call [Builder.metadata] with a well-typed
-                 * [Subscription.Metadata] value instead. This method is primarily for setting the
+                 * [com.dodopayments.api.models.subscriptions.Subscription.Metadata] value instead. This method is primarily for setting the
                  * field to an undocumented or not yet supported value.
                  */
-                fun metadata(metadata: JsonField<Subscription.Metadata>) = apply {
+                fun metadata(metadata: JsonField<com.dodopayments.api.models.subscriptions.Subscription.Metadata>) = apply {
                     this.metadata = metadata
                 }
 
@@ -4586,7 +4586,7 @@ private constructor(
             private val createdAt: JsonField<OffsetDateTime>,
             private val customer: JsonField<CustomerLimitedDetails>,
             private val isPartial: JsonField<Boolean>,
-            private val metadata: JsonField<Refund.Metadata>,
+            private val metadata: JsonField<com.dodopayments.api.models.refunds.Refund.Metadata>,
             private val paymentId: JsonField<String>,
             private val refundId: JsonField<String>,
             private val status: JsonField<RefundStatus>,
@@ -4613,7 +4613,7 @@ private constructor(
                 isPartial: JsonField<Boolean> = JsonMissing.of(),
                 @JsonProperty("metadata")
                 @ExcludeMissing
-                metadata: JsonField<Refund.Metadata> = JsonMissing.of(),
+                metadata: JsonField<com.dodopayments.api.models.refunds.Refund.Metadata> = JsonMissing.of(),
                 @JsonProperty("payment_id")
                 @ExcludeMissing
                 paymentId: JsonField<String> = JsonMissing.of(),
@@ -4707,7 +4707,7 @@ private constructor(
              *   is unexpectedly missing or null (e.g. if the server responded with an unexpected
              *   value).
              */
-            fun metadata(): Refund.Metadata = metadata.getRequired("metadata")
+            fun metadata(): com.dodopayments.api.models.refunds.Refund.Metadata = metadata.getRequired("metadata")
 
             /**
              * The unique identifier of the payment associated with the refund.
@@ -4815,7 +4815,7 @@ private constructor(
              */
             @JsonProperty("metadata")
             @ExcludeMissing
-            fun _metadata(): JsonField<Refund.Metadata> = metadata
+            fun _metadata(): JsonField<com.dodopayments.api.models.refunds.Refund.Metadata> = metadata
 
             /**
              * Returns the raw JSON value of [paymentId].
@@ -4916,7 +4916,7 @@ private constructor(
                 private var createdAt: JsonField<OffsetDateTime>? = null
                 private var customer: JsonField<CustomerLimitedDetails>? = null
                 private var isPartial: JsonField<Boolean>? = null
-                private var metadata: JsonField<Refund.Metadata>? = null
+                private var metadata: JsonField<com.dodopayments.api.models.refunds.Refund.Metadata>? = null
                 private var paymentId: JsonField<String>? = null
                 private var refundId: JsonField<String>? = null
                 private var status: JsonField<RefundStatus>? = null
@@ -4997,16 +4997,16 @@ private constructor(
                 fun isPartial(isPartial: JsonField<Boolean>) = apply { this.isPartial = isPartial }
 
                 /** Additional metadata stored with the refund. */
-                fun metadata(metadata: Refund.Metadata) = metadata(JsonField.of(metadata))
+                fun metadata(metadata: com.dodopayments.api.models.refunds.Refund.Metadata) = metadata(JsonField.of(metadata))
 
                 /**
                  * Sets [Builder.metadata] to an arbitrary JSON value.
                  *
-                 * You should usually call [Builder.metadata] with a well-typed [Refund.Metadata]
+                 * You should usually call [Builder.metadata] with a well-typed [com.dodopayments.api.models.refunds.Refund.Metadata]
                  * value instead. This method is primarily for setting the field to an undocumented
                  * or not yet supported value.
                  */
-                fun metadata(metadata: JsonField<Refund.Metadata>) = apply {
+                fun metadata(metadata: JsonField<com.dodopayments.api.models.refunds.Refund.Metadata>) = apply {
                     this.metadata = metadata
                 }
 
@@ -7075,7 +7075,7 @@ private constructor(
             private val isCredit: JsonField<Boolean>,
             private val overageAfter: JsonField<String>,
             private val overageBefore: JsonField<String>,
-            private val transactionType: JsonField<CreditLedgerEntry.TransactionType>,
+            private val transactionType: JsonField<com.dodopayments.api.models.creditentitlements.balances.CreditLedgerEntry.TransactionType>,
             private val description: JsonField<String>,
             private val grantId: JsonField<String>,
             private val referenceId: JsonField<String>,
@@ -7119,7 +7119,7 @@ private constructor(
                 overageBefore: JsonField<String> = JsonMissing.of(),
                 @JsonProperty("transaction_type")
                 @ExcludeMissing
-                transactionType: JsonField<CreditLedgerEntry.TransactionType> = JsonMissing.of(),
+                transactionType: JsonField<com.dodopayments.api.models.creditentitlements.balances.CreditLedgerEntry.TransactionType> = JsonMissing.of(),
                 @JsonProperty("description")
                 @ExcludeMissing
                 description: JsonField<String> = JsonMissing.of(),
@@ -7259,7 +7259,7 @@ private constructor(
              *   is unexpectedly missing or null (e.g. if the server responded with an unexpected
              *   value).
              */
-            fun transactionType(): CreditLedgerEntry.TransactionType =
+            fun transactionType(): com.dodopayments.api.models.creditentitlements.balances.CreditLedgerEntry.TransactionType =
                 transactionType.getRequired("transaction_type")
 
             /**
@@ -7405,7 +7405,7 @@ private constructor(
              */
             @JsonProperty("transaction_type")
             @ExcludeMissing
-            fun _transactionType(): JsonField<CreditLedgerEntry.TransactionType> = transactionType
+            fun _transactionType(): JsonField<com.dodopayments.api.models.creditentitlements.balances.CreditLedgerEntry.TransactionType> = transactionType
 
             /**
              * Returns the raw JSON value of [description].
@@ -7505,7 +7505,7 @@ private constructor(
                 private var isCredit: JsonField<Boolean>? = null
                 private var overageAfter: JsonField<String>? = null
                 private var overageBefore: JsonField<String>? = null
-                private var transactionType: JsonField<CreditLedgerEntry.TransactionType>? = null
+                private var transactionType: JsonField<com.dodopayments.api.models.creditentitlements.balances.CreditLedgerEntry.TransactionType>? = null
                 private var description: JsonField<String> = JsonMissing.of()
                 private var grantId: JsonField<String> = JsonMissing.of()
                 private var referenceId: JsonField<String> = JsonMissing.of()
@@ -7674,17 +7674,17 @@ private constructor(
                     this.overageBefore = overageBefore
                 }
 
-                fun transactionType(transactionType: CreditLedgerEntry.TransactionType) =
+                fun transactionType(transactionType: com.dodopayments.api.models.creditentitlements.balances.CreditLedgerEntry.TransactionType) =
                     transactionType(JsonField.of(transactionType))
 
                 /**
                  * Sets [Builder.transactionType] to an arbitrary JSON value.
                  *
                  * You should usually call [Builder.transactionType] with a well-typed
-                 * [CreditLedgerEntry.TransactionType] value instead. This method is primarily for
+                 * [com.dodopayments.api.models.creditentitlements.balances.CreditLedgerEntry.TransactionType] value instead. This method is primarily for
                  * setting the field to an undocumented or not yet supported value.
                  */
-                fun transactionType(transactionType: JsonField<CreditLedgerEntry.TransactionType>) =
+                fun transactionType(transactionType: JsonField<com.dodopayments.api.models.creditentitlements.balances.CreditLedgerEntry.TransactionType>) =
                     apply {
                         this.transactionType = transactionType
                     }


### PR DESCRIPTION
## Summary

- Fully qualifies `Payment.Metadata`, `Subscription.Metadata`, `Refund.Metadata`, and `CreditLedgerEntry.TransactionType` type references in `WebhookPayload.kt` that were shadowed by same-named inner classes within `WebhookPayload.Data`
- The OpenAPI spec code regeneration (v1.86.0) overwrote a previous fix for similar type-shadowing issues, reintroducing unresolved reference compile errors for these 4 nested types (32 occurrences total)
- Build now compiles successfully